### PR TITLE
Avoid "TypeError Unknown body" when passing in an object as the body

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -27,6 +27,14 @@ describe('servie', () => {
 
       expect(res.status).toBe(200)
     })
+
+    it('should json encode body if a simple object', () => {
+      const req = new Request({ url: '/json' })
+      const res = new Response(req, { body: { foo: 'bar' } })
+
+      expect(res.headers.get('Content-Type')).toBe('application/json')
+      expect(res.body).toEqual('{\"foo\":\"bar\"}')
+    })
   })
 
   describe('cloning', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -337,6 +337,7 @@ export class Common implements CommonOptions {
       this._body = str
       this.type = 'application/json'
       this.length = Buffer.byteLength(str)
+      return
     }
 
     throw new TypeError(`Unknown body: ${body}`)


### PR DESCRIPTION
I'm receiving TypeError: Unknown body: [object Object] when setting body to an object as there isn't a return statement under that isBasicObject check.
